### PR TITLE
Define a custom close event filter passed as property to be applied within the inspectCloseEvent method

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {mount} from '@vue/test-utils';
+import {mount, shallowMount} from '@vue/test-utils';
 import VueDatePick from '../src/vueDatePick';
 import Vue from 'vue';
 import fecha from 'fecha';
@@ -49,6 +49,33 @@ describe('Vue date pick', () => {
             ['2017-12-31']
         ]);
 
+    });
+
+    it('filters out unwanted focusin event from an external element', async () => {
+        const externalElement = document.createElement('div');
+        externalElement.setAttribute('class', 'modal');
+        document.body.appendChild(externalElement);
+
+        const datePickerElement = document.createElement('div');
+        datePickerElement.id = 'root';
+        document.body.appendChild(datePickerElement);
+
+        const wrapper = await shallowMount(VueDatePick, {
+            propsData: {
+                customCloseEventFilter: e => !e.target.classList.contains('modal')
+            },
+            attachTo: '#root'
+        });
+
+        wrapper.vm.open();
+
+        externalElement.addEventListener('focusin', wrapper.vm.inspectCloseEvent);
+        const externalFocusinEvent = new FocusEvent('focusin');
+        externalElement.dispatchEvent(externalFocusinEvent);
+
+        await wrapper.vm.$nextTick();
+        assert.isTrue(wrapper.find('.vdpOuterWrap').exists());
+        wrapper.destroy();
     });
 
     it('can use alternate parsing engine', async () => {

--- a/src/vueDatePick.vue
+++ b/src/vueDatePick.vue
@@ -257,6 +257,10 @@ export default {
         startWeekOnSunday: {
             type: Boolean,
             default: false
+        },
+        customCloseEventFilter: {
+            type: Function,
+            default: () => true
         }
     },
 
@@ -651,6 +655,10 @@ export default {
         },
 
         inspectCloseEvent(event) {
+
+            if (!this.customCloseEventFilter(event)) {
+                return;
+            }
 
             if (event.keyCode) {
                 event.keyCode === 27 && this.close();


### PR DESCRIPTION
There is a bug for the date-picker when using it within Bootstrap 4's modal component. 

The user is unable to select the date by clicking on the date in the calendar. This is because whenever the user clicks in the calendar a `focusin` event gets also fired up from the bootstrap modal that closes the calendar before the click has taken place.

This could also be related to issue #64 (the div element with the `tabindex` might be firing up an unwanted `focusin` event ).

With the additional component property `customCloseEventFilter` the client of the component can pass a custom event filter to prevent ie. an unwanted `focusin` event from closing the calendar.

The example below prevents an unwanted `focusin` event from Bootstrap 4's modal.

```javascript
const wrapper = await shallowMount(VueDatePick, {
    propsData: {
        customCloseEventFilter: e => !e.target.classList.contains('modal')
    },
    attachTo: '#root'
});
```